### PR TITLE
fix uni-card__header-avatar render error

### DIFF
--- a/uni_modules/uni-card/components/uni-card/uni-card.vue
+++ b/uni_modules/uni-card/components/uni-card/uni-card.vue
@@ -184,6 +184,7 @@
 				.uni-card__header-avatar-image {
 					flex: 1;
 					width: 40px;
+					height: 100%;
 				}
 			}
 


### PR DESCRIPTION
如果不加 "height: 100%;",会导致header-avatar的渲染比为1/6,头象过长,显示不出来.